### PR TITLE
Support Screenshots on Web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ gif = { version = "0.11", optional = true }
 color_quant = { version = "1.1.0", optional = true }
 rayon = { version = "1.5", optional = true }
 fnv = { version = "1" , optional = true}
+base64 = "0.13.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.58" }
@@ -48,4 +49,5 @@ features = [
 	"Element",
 	"HtmlElement",
 	"FileReader",
+	"HtmlCollection",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,20 @@ gif = { version = "0.11", optional = true }
 color_quant = { version = "1.1.0", optional = true }
 rayon = { version = "1.5", optional = true }
 fnv = { version = "1" , optional = true}
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { version = "0.3.58" }
+wasm-bindgen = "0.2.81"
+wasm-bindgen-futures = "0.4.31"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "0.3.58"
+features = [
+	"Window",
+	"Document",
+	"Blob",
+	"BlobPropertyBag",
+	"Element",
+	"HtmlElement",
+	"FileReader",
+]

--- a/src/formats/gif.rs
+++ b/src/formats/gif.rs
@@ -24,8 +24,11 @@ use crate::image_utils::{frame_data_to_rgba_image, to_rgba};
 pub struct RecordGif;
 pub type CaptureGifRecording = CaptureRecording<RecordGif>;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Component)]
-pub struct SaveGifRecording(Task<()>);
+pub struct SaveGifRecording(pub Task<()>);
+
+#[cfg(not(target_arch = "wasm32"))]
 impl HasTaskStatus for SaveGifRecording {
 	fn is_done(&mut self) -> bool {
 		let result = future::block_on(future::poll_once(&mut self.0));
@@ -150,11 +153,10 @@ pub fn capture_gif_recording(
 				()
 			});
 
-			if cfg!(target_arch = "wasm32") {
-				task.detach();
-			} else {
-				commands.spawn().insert(SaveGifRecording(task));
-			}
+			#[cfg(target_arch = "wasm32")]
+			task.detach();
+			#[cfg(not(target_arch = "wasm32"))]
+			commands.spawn().insert(SaveGifRecording(task));
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod formats;
 mod image_utils;
 pub mod management;
 pub mod render;
+#[cfg(target_arch = "wasm32")]
+mod web_utils;
 
 mod plugin {
 	use bevy_app::{App, CoreStage, Plugin};

--- a/src/web_utils.rs
+++ b/src/web_utils.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use js_sys::{Array, Date, Promise, Uint8Array};
 use wasm_bindgen::closure::Closure;
+use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Blob, BlobPropertyBag, Document, FileReader, Window};
@@ -88,59 +89,106 @@ pub fn focus_on_first_of_type(element_type: &str) {
 		window.document(),
 		"Window did not contain a document to attach to while saving screenshot"
 	);
+	let element = null_return!(
+		document.get_elements_by_tag_name(element_type).item(0),
+		"Could not find element to focus on"
+	);
+
+	err_return!(
+		element.dyn_into::<web_sys::HtmlElement>(),
+		"Failed to attach blob url"
+	)
+	.focus();
+}
+
+#[wasm_bindgen(inline_js = r#"
+export async function save_bytes(filename, bytes) {
+	const reader = new FileReader()
+	const promise = new Promise(function (resolve, reject) {
+		function onSuccess() {
+			resolve(reader.result)
+			reader.removeEventListener('load', onSuccess)
+			reader.removeEventListener('error', onFailure)
+		}
+		function onFailure(e) {
+			reject(e)
+			reader.removeEventListener('load', onSuccess)
+			reader.removeEventListener('error', onFailure)
+		}
+		reader.addEventListener('load', onSuccess)
+		reader.addEventListener('error', onFailure)
+	})
+	reader.readAsDataURL(new Blob(bytes))
+	
+	const value = await promise
+	
+	const link = document.createElement('a')
+	link.href = value
+	link.download = filename
+	link.click()
+ }"#)]
+extern "C" {
+	fn save_bytes(file_name: String, bytes: &[u8]) -> Promise;
 }
 
 async fn download_bytes_inner(file_name: PathBuf, bytes: Vec<u8>) {
-	let bytes = bytes.as_slice();
-	let js_byte_array = Uint8Array::from(bytes);
-	let js_array = Array::new();
-	js_array.push(&js_byte_array.buffer());
-
-	let blob = err_return!(
-		Blob::new_with_u8_array_sequence_and_options(
-			&js_array,
-			BlobPropertyBag::new().type_("image/png"),
-		),
-		"Failed to create screenshot blob data"
-	);
-
-	let obj_url = err_return!(
-		JsFuture::from(read_to_data(&blob)).await,
-		"Failed to create data url for screenshot"
-	);
-	let obj_url_string = null_return!(
-		obj_url.as_string(),
-		"Couldn't convert the data url from a JsValue to a String"
-	);
-	let window: Window = null_return!(
-		web_sys::window(),
-		"Didn't find a window to attach to while saving screenshot"
-	);
-	let document: Document = null_return!(
-		window.document(),
-		"Window did not contain a document to attach to while saving screenshot"
-	);
-	let link = err_return!(
-		document.create_element("a"),
-		"Could not create download link handler"
-	);
-	err_return!(
-		link.set_attribute("href", obj_url_string.as_str()),
-		"Failed to attach blob url"
-	);
-	err_return!(
-		link.set_attribute("download", format!("{}", file_name.display()).as_str()),
-		"Failed to attach file name"
-	);
-	let html_link = err_return!(
-		link.dyn_into::<web_sys::HtmlElement>(),
-		"Could not get interactable version of download link"
-	);
-
-	html_link.click();
-
-	log::info!("Saving image to path {}", file_name.display());
+	JsFuture::from(save_bytes(
+		format!("{}", file_name.display()),
+		bytes.as_slice(),
+	));
+	// .await;
 }
+// async fn _download_bytes_inner(file_name: PathBuf, bytes: Vec<u8>) {
+// 	let bytes = bytes.as_slice();
+// 	let js_byte_array = Uint8Array::from(bytes);
+// 	let js_array = Array::new();
+// 	js_array.push(&js_byte_array.buffer());
+//
+// 	let blob = err_return!(
+// 		Blob::new_with_u8_array_sequence_and_options(
+// 			&js_array,
+// 			BlobPropertyBag::new().type_("image/png"),
+// 		),
+// 		"Failed to create screenshot blob data"
+// 	);
+//
+// 	let obj_url = err_return!(
+// 		JsFuture::from(read_to_data(&blob)).await,
+// 		"Failed to create data url for screenshot"
+// 	);
+// 	let obj_url_string = null_return!(
+// 		obj_url.as_string(),
+// 		"Couldn't convert the data url from a JsValue to a String"
+// 	);
+// 	let window: Window = null_return!(
+// 		web_sys::window(),
+// 		"Didn't find a window to attach to while saving screenshot"
+// 	);
+// 	let document: Document = null_return!(
+// 		window.document(),
+// 		"Window did not contain a document to attach to while saving screenshot"
+// 	);
+// 	let link = err_return!(
+// 		document.create_element("a"),
+// 		"Could not create download link handler"
+// 	);
+// 	err_return!(
+// 		link.set_attribute("href", obj_url_string.as_str()),
+// 		"Failed to attach blob url"
+// 	);
+// 	err_return!(
+// 		link.set_attribute("download", format!("{}", file_name.display()).as_str()),
+// 		"Failed to attach file name"
+// 	);
+// 	let html_link = err_return!(
+// 		link.dyn_into::<web_sys::HtmlElement>(),
+// 		"Could not get interactable version of download link"
+// 	);
+//
+// 	html_link.click();
+//
+// 	log::info!("Saving image to path {}", file_name.display());
+// }
 
 pub fn download_bytes(file_name: PathBuf, bytes: Vec<u8>) {
 	wasm_bindgen_futures::spawn_local(download_bytes_inner(file_name, bytes));

--- a/src/web_utils.rs
+++ b/src/web_utils.rs
@@ -1,0 +1,151 @@
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use js_sys::{Array, Date, Promise, Uint8Array};
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Blob, BlobPropertyBag, Document, FileReader, Window};
+
+macro_rules! null_return {
+	($nullable: expr, $message: literal) => {
+		match $nullable {
+			Some(value) => value,
+			None => {
+				log::error!($message);
+				return;
+			}
+		}
+	};
+	($nullable: expr, $message: literal, $on_error: expr) => {
+		match $nullable {
+			Some(value) => value,
+			None => {
+				log::error!($message);
+				$on_error.call1(&JsValue::NULL, &JsValue::from_str($message));
+				return;
+			}
+		}
+	};
+}
+macro_rules! err_return {
+	($nullable: expr, $message: literal) => {
+		match $nullable {
+			Ok(value) => value,
+			Err(e) => {
+				log::error!("{}; {:?}", $message, e);
+				return;
+			}
+		}
+	};
+	($nullable: expr, $message: literal, $on_error: expr) => {
+		match $nullable {
+			Ok(value) => value,
+			Err(e) => {
+				log::error!("{}; {:?}", $message, e);
+				$on_error.call1(&JsValue::NULL, &e);
+				return;
+			}
+		}
+	};
+}
+
+fn read_to_data(blob: &Blob) -> Promise {
+	Promise::new(&mut |resolve, reject| {
+		let file_reader: FileReader =
+			err_return!(FileReader::new(), "Failed to create a file reader", reject);
+
+		let reject = Rc::new(reject);
+		let file_reader = Rc::new(file_reader);
+
+		let closure_file_reader = file_reader.clone();
+		let closure_reject = reject.clone();
+		let mut closure = Closure::once(move || {
+			let value = err_return!(
+				closure_file_reader.result(),
+				"Could not get file reader result",
+				closure_reject
+			);
+			resolve.call1(&JsValue::NULL, &value);
+		});
+
+		file_reader.set_onload(Some(closure.as_ref().unchecked_ref()));
+		closure.forget();
+		err_return!(
+			file_reader.read_as_data_url(blob),
+			"Failed to read the image data as a data url",
+			reject
+		);
+	})
+}
+
+pub fn focus_on_first_of_type(element_type: &str) {
+	let window: Window = null_return!(
+		web_sys::window(),
+		"Didn't find a window to attach to while saving screenshot"
+	);
+	let document: Document = null_return!(
+		window.document(),
+		"Window did not contain a document to attach to while saving screenshot"
+	);
+}
+
+async fn download_bytes_inner(file_name: PathBuf, bytes: Vec<u8>) {
+	let bytes = bytes.as_slice();
+	let js_byte_array = Uint8Array::from(bytes);
+	let js_array = Array::new();
+	js_array.push(&js_byte_array.buffer());
+
+	let blob = err_return!(
+		Blob::new_with_u8_array_sequence_and_options(
+			&js_array,
+			BlobPropertyBag::new().type_("image/png"),
+		),
+		"Failed to create screenshot blob data"
+	);
+
+	let obj_url = err_return!(
+		JsFuture::from(read_to_data(&blob)).await,
+		"Failed to create data url for screenshot"
+	);
+	let obj_url_string = null_return!(
+		obj_url.as_string(),
+		"Couldn't convert the data url from a JsValue to a String"
+	);
+	let window: Window = null_return!(
+		web_sys::window(),
+		"Didn't find a window to attach to while saving screenshot"
+	);
+	let document: Document = null_return!(
+		window.document(),
+		"Window did not contain a document to attach to while saving screenshot"
+	);
+	let link = err_return!(
+		document.create_element("a"),
+		"Could not create download link handler"
+	);
+	err_return!(
+		link.set_attribute("href", obj_url_string.as_str()),
+		"Failed to attach blob url"
+	);
+	err_return!(
+		link.set_attribute("download", format!("{}", file_name.display()).as_str()),
+		"Failed to attach file name"
+	);
+	let html_link = err_return!(
+		link.dyn_into::<web_sys::HtmlElement>(),
+		"Could not get interactable version of download link"
+	);
+
+	html_link.click();
+
+	log::info!("Saving image to path {}", file_name.display());
+}
+
+pub fn download_bytes(file_name: PathBuf, bytes: Vec<u8>) {
+	wasm_bindgen_futures::spawn_local(download_bytes_inner(file_name, bytes));
+}
+
+pub fn get_now() -> f64 {
+	Date::now()
+}


### PR DESCRIPTION
Web targets do not support two things currently used by all formats: The file system and task pools.

This PR updates single frame capture (screenshots) to use standard web techniques for downloading files, and to skip the task pool. Instead, tasks are simply detached as they did not return a result in the first place.

Changes:

## Added
- Wasm support for single frame capture
- Web utilities, using `web-sys` and `js-sys` to download the frame buffer after it has been formatted as a PNG